### PR TITLE
[codex] 不要なdotfiles記述を整理する

### DIFF
--- a/STARSHIP.md
+++ b/STARSHIP.md
@@ -5,11 +5,6 @@ Starshipがどのような構成になっているのかを記録するための
 ## 公式
 https://starship.rs/
 
-## シンボリックリンク
-```bash
-ln -fsv $HOME/dotfiles/starship/starship.toml $HOME/.starship/starship.toml
-```
-
 ## 環境変数
 Docs: https://starship.rs/ja-JP/config/#config-file-location
 ```bash
@@ -21,11 +16,9 @@ export STARSHIP_CACHE="$HOME/.starship/cache"
 ## Font
 Docs: https://www.nerdfonts.com/font-downloads
 ```bash
-brew tap homebrew/cask-fonts &&
 brew install --cask font-hack-nerd-font
 ```
-VS CodeやWarpのフォントを`Hack Nerd Font`に設定。  
-Warpは「View all available system fonts」にチェックを入れないとこのフォントは選択できません。  
+VS Codeなどのターミナル表示に使うフォントを`Hack Nerd Font`に設定。  
 それ以外のフォントにする際はアイコンが文字化けしないものを選択してください。
 
 ## 参考

--- a/dot_Brewfile
+++ b/dot_Brewfile
@@ -1,13 +1,4 @@
 ##
-## tap
-## 
-tap "homebrew/bundle"
-tap "homebrew/cask"
-tap "homebrew/cask-fonts"
-tap "homebrew/core"
-
-
-##
 ## brew
 ##
 brew "coreutils"
@@ -30,41 +21,23 @@ brew "webp"
 ## cask
 ##
 cask "1password"
-cask "brave-browser"
 cask "deepl"
 cask "discord"
-cask "docker"
 cask "firefox"
 cask "ghostty"
 cask "google-chrome"
-#cask "google-drive"
-#cask "microsoft-excel"
-#cask "microsoft-powerpoint"
-#cask "microsoft-word"
 cask "notion"
 cask "raycast"
-#cask "slack"
+cask "slack"
 cask "visual-studio-code"
-#cask "zoom"
-# JetBrains
-cask "datagrip"
-cask "goland"
-cask "intellij-idea"
-cask "jetbrains-toolbox"
 
 # font
 cask "font-hack-nerd-font"
 
-
 ##
 ## mas
 ##
-if OS.mac?  # macの時のみ実行。(linux[wsl]で使う可能性があるため)
-  mas "LINE",                 id: 539883307
-  #mas "Microsoft Excel",      id: 462058435
-  #mas "Microsoft PowerPoint", id: 462062816
-  #mas "Microsoft Word",       id: 462054704
+if OS.mac?  # macの時のみ実行
   mas "RunCat",               id: 1429033973
   mas "Skitch",               id: 425955336
-  mas "Twitter",              id: 1482454543
 end

--- a/dot_config/zsh/homebrew.zsh
+++ b/dot_config/zsh/homebrew.zsh
@@ -1,36 +1,16 @@
 # homebrewでインストールしたパッケージのpathを通す設定
 
-prepend_path_if_exists () {
-  if [[ -d "$1" ]]; then
-    export PATH="$1:$PATH"
-  fi
-}
+# coreutils (GNUのやつ)
+export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
 
-if command -v brew >/dev/null 2>&1; then
-  HOMEBREW_PREFIX="$(brew --prefix)"
-elif [[ -x /opt/homebrew/bin/brew ]]; then
-  HOMEBREW_PREFIX="/opt/homebrew"
-elif [[ -x /usr/local/bin/brew ]]; then
-  HOMEBREW_PREFIX="/usr/local"
-fi
+# make (gmake)
+export PATH="/opt/homebrew/opt/make/libexec/gnubin:$PATH"
 
-if [[ -n "${HOMEBREW_PREFIX:-}" ]]; then
-  # coreutils (GNU)
-  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin"
+# sed (gsed)
+export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
 
-  # make (gmake)
-  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/make/libexec/gnubin"
+# curl (gcurl)
+export PATH="/opt/homebrew/opt/curl/bin:$PATH"
 
-  # sed (gsed)
-  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin"
-
-  # curl (gcurl)
-  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/curl/bin"
-
-  # grep (ggrep)
-  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/grep/libexec/gnubin"
-
-  unset HOMEBREW_PREFIX
-fi
-
-unfunction prepend_path_if_exists
+# grep (ggrep)
+export PATH="/opt/homebrew/opt/grep/libexec/gnubin:$PATH"

--- a/dot_config/zsh/homebrew.zsh
+++ b/dot_config/zsh/homebrew.zsh
@@ -1,16 +1,36 @@
 # homebrewでインストールしたパッケージのpathを通す設定
 
-# coreutils (GNUのやつ)
-export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+prepend_path_if_exists () {
+  if [[ -d "$1" ]]; then
+    export PATH="$1:$PATH"
+  fi
+}
 
-# make (gmake)
-export PATH="/opt/homebrew/opt/make/libexec/gnubin:$PATH"
+if command -v brew >/dev/null 2>&1; then
+  HOMEBREW_PREFIX="$(brew --prefix)"
+elif [[ -x /opt/homebrew/bin/brew ]]; then
+  HOMEBREW_PREFIX="/opt/homebrew"
+elif [[ -x /usr/local/bin/brew ]]; then
+  HOMEBREW_PREFIX="/usr/local"
+fi
 
-# sed (gsed)
-export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
+if [[ -n "${HOMEBREW_PREFIX:-}" ]]; then
+  # coreutils (GNU)
+  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin"
 
-# curl (gcurl)
-export PATH="/opt/homebrew/opt/curl/bin:$PATH"
+  # make (gmake)
+  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/make/libexec/gnubin"
 
-# grep (ggrep)
-export PATH="/opt/homebrew/opt/grep/libexec/gnubin:$PATH"
+  # sed (gsed)
+  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin"
+
+  # curl (gcurl)
+  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/curl/bin"
+
+  # grep (ggrep)
+  prepend_path_if_exists "$HOMEBREW_PREFIX/opt/grep/libexec/gnubin"
+
+  unset HOMEBREW_PREFIX
+fi
+
+unfunction prepend_path_if_exists


### PR DESCRIPTION
## 概要

不要な記述・古い記述・現在の構成に合わない記述を整理します。

## 変更内容

- `dot_Brewfile` から不要なtap定義を削除
- `dot_Brewfile` から不要になったコメントアウト済みの項目や古いコメントを整理
- Starshipのドキュメントから旧シンボリックリンク手順を削除
- Starshipのフォント導入手順から不要な `homebrew/cask-fonts` tap を削除
- Warp向けの古い説明を削除し、汎用的なターミナル表示の説明に変更

Refs #6

## 確認したこと

- `zsh -n dot_zshenv`
- `zsh -n dot_zshrc`
- `zsh -n dot_config/zsh/homebrew.zsh`
- `zsh -n dot_config/zsh/aliases.zsh`
- `zsh -n dot_config/zsh/starship.zsh`
- `sh -n run_once_before_00-install-homebrew.sh.tmpl`
- `sh -n run_onchange_10_brew-bundle.sh.tmpl`
- 古い記述の検索で対象パターンが残っていないことを確認

## 補足

`brew bundle check --file=dot_Brewfile` は実行しましたが、ローカル環境で未インストールまたは未更新の項目があるため失敗しています。Brewfile自体は読み込まれており、未充足依存の判定まで進んでいます。

ツールの要否判断はこのPRでは深追いせず、既に削除されていた `dot_Brewfile` の変更はそのまま引き継いでいます。
