### PR TITLE
feat: Claude Code statusline を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,3 @@
 ```bash
 sh -c "$(curl -fsLS https://get.chezmoi.io)" -- init --apply https://github.com/HidakaRintaro/dotfiles.git
 ```
-
-## Tools
-
-Node.js、npm、yarn、pnpm、PHP、Goはmiseで管理する。
-
-```bash
-mise install
-mise ls
-```

--- a/dot_Brewfile
+++ b/dot_Brewfile
@@ -1,6 +1,7 @@
 ##
 ## brew
 ##
+brew "ccusage"
 brew "coreutils"
 brew "curl"
 brew "gh"
@@ -11,6 +12,7 @@ brew "gnu-sed"
 brew "grep"
 brew "jnv"
 brew "make"
+brew "mas"
 brew "mise"
 brew "neovim"
 brew "starship"

--- a/dot_claude/executable_statusline.sh
+++ b/dot_claude/executable_statusline.sh
@@ -43,8 +43,8 @@ IFS=$'\x1f' read -r model effort cwd project wt \
 # セマンティックな役割で定義し、用途ごとに使い分ける
 RST=$'\033[0m'
 DIM=$'\033[2m'
-C_TEXT=$'\033[38;2;171;178;191m'    # #ABB2BF    - 基本テキスト (モデル, コスト金額, %)
-C_SUB=$'\033[38;2;130;137;151m'     # #828997    - 補助テキスト (ラベル, リセット時刻, 未追跡)
+C_TEXT=$'\033[38;2;204;204;204m'    # #CCCCCC    - 基本テキスト (Ghostty Dark Modern foreground)
+C_SUB=$'\033[38;2;171;178;191m'     # #ABB2BF    - 補助テキスト (ラベル, リセット時刻, 未追跡)
 C_OK=$'\033[38;2;78;201;148m'       # #4EC994 緑 - 正常 (staged)
 C_WARN=$'\033[38;2;226;181;106m'    # #E2B56A 黄 - 警告 (unstaged)
 C_DANGER=$'\033[38;2;224;108;117m'  # #E06C75 赤 - 危険 (コンフリクト)
@@ -153,7 +153,7 @@ usd_jpy_rate() {
     (curl -s --max-time 3 \
       "https://api.frankfurter.dev/v1/latest?base=USD&symbols=JPY" 2>/dev/null |
       jq -r '.rates.JPY // empty' >"$cache.tmp" \
-      && [ -s "$cache.tmp" ] && mv "$cache.tmp" "$cache") &
+      && [ -s "$cache.tmp" ] && mv -f "$cache.tmp" "$cache") &
   fi
   cat "$cache" 2>/dev/null
 }
@@ -165,36 +165,37 @@ fmt_jpy() {
   [ -z "$usd" ] && return
   local jpy
   jpy=$(awk -v u="$usd" -v r="$JPY_RATE" 'BEGIN{printf "%d", int(u*r+0.5)}')
-  [ "$jpy" = "0" ] && return
   echo "$(echo "$jpy" | rev | sed 's/[0-9][0-9][0-9]/&,/g' | rev | sed 's/^,//')"
 }
 
-# ── 1日のコスト (ccusage, 5分キャッシュ) ─────────────────────────────────────
+# ── 1日のコスト (ccusage, 1分キャッシュ) ─────────────────────────────────────
 daily_cost() {
   local cache="$CACHE_DIR/daily_$(date +%Y%m%d)"
   local now mtime
   now=$(date +%s)
   mtime=$(file_mtime "$cache")
-  if [ $((now - mtime)) -gt 300 ]; then
+  if [ $((now - mtime)) -gt 60 ]; then
     touch "$cache"
+    find "$CACHE_DIR" -maxdepth 1 -name 'daily_*' ! -name "daily_$(date +%Y%m%d)" -delete 2>/dev/null &
     (ccusage daily --since "$(date +%Y%m%d)" --json 2>/dev/null |
       jq -r '.totals.totalCost // empty' >"$cache.tmp" \
-      && mv "$cache.tmp" "$cache") &
+      && mv -f "$cache.tmp" "$cache") &
   fi
   cat "$cache" 2>/dev/null
 }
 
-# ── 7日間のコスト (ccusage, 5分キャッシュ) ───────────────────────────────────
+# ── 7日間のコスト (ccusage, 1分キャッシュ) ───────────────────────────────────
 weekly_cost() {
   local cache="$CACHE_DIR/weekly_$(date +%Y%m%d)"
   local now mtime
   now=$(date +%s)
   mtime=$(file_mtime "$cache")
-  if [ $((now - mtime)) -gt 300 ]; then
+  if [ $((now - mtime)) -gt 60 ]; then
     touch "$cache"
+    find "$CACHE_DIR" -maxdepth 1 -name 'weekly_*' ! -name "weekly_$(date +%Y%m%d)" -delete 2>/dev/null &
     (ccusage weekly --json 2>/dev/null |
       jq -r '.totals.totalCost // empty' >"$cache.tmp" \
-      && mv "$cache.tmp" "$cache") &
+      && mv -f "$cache.tmp" "$cache") &
   fi
   cat "$cache" 2>/dev/null
 }
@@ -205,6 +206,9 @@ now_ts=$(date +%s)
 git_mtime=$(file_mtime "$GIT_CACHE")
 
 if [ $((now_ts - git_mtime)) -gt 5 ]; then
+  # 初回作成時（新セッション）に他セッションの古いキャッシュを削除
+  [ ! -f "$GIT_CACHE" ] && find "$CACHE_DIR" -maxdepth 1 -name 'git-*' \
+    ! -name "git-${session_id:-nosession}" -delete 2>/dev/null &
   git_dir="${cwd:-$(pwd)}"
   if git -C "$git_dir" --no-optional-locks rev-parse --is-inside-work-tree \
       >/dev/null 2>&1; then
@@ -268,7 +272,7 @@ line1="${I_DIR} ${C_INFO}${dir_display}${RST}"
 if [ -n "$git_remote_slug" ]; then
   expected_path="$HOME/src/github.com/${git_remote_slug}"
   if [ "${project:-$cwd}" != "$expected_path" ]; then
-    line1+="${SEP}${I_GITHUB} $(printf '\033]8;;https://github.com/%s\a%s\033]8;;\a' "$git_remote_slug" "$git_remote_slug")"
+    line1+="${SEP}${I_GITHUB} ${C_TEXT}$(printf '\033]8;;https://github.com/%s\a%s\033]8;;\a' "$git_remote_slug" "$git_remote_slug")${RST}"
   fi
 fi
 
@@ -308,16 +312,24 @@ line2="${I_MODEL} ${C_TEXT}${model}${RST}"
 line2+="${SEP}${C_OK}$(printf '\033]8;;https://status.claude.com\a%s OK\033]8;;\a' "${I_STATUS_OK}")${RST}"
 
 # セッションコスト（JSON から取得、固定レートで円換算）
-session_cost=$(fmt_jpy "$cost_usd")
-[ -n "$session_cost" ] && line2+="${SEP}${I_COST}${C_TEXT}${session_cost}${RST}${C_SUB}(session)${RST}"
+session_cost=$(fmt_jpy "${cost_usd:-0}")
+line2+="${SEP}${I_COST}${C_TEXT}${session_cost}${RST}${C_SUB}(session)${RST}"
 
-# 1日のコスト
-daily=$(fmt_jpy "$(daily_cost)")
-[ -n "$daily" ] && line2+="${SEP}${I_COST}${C_TEXT}${daily}${RST}${C_SUB}(daily)${RST}"
+# 1日のコスト（キャッシュ未取得中は「…」で計算中を示す）
+daily_raw=$(daily_cost)
+if [ -z "$daily_raw" ]; then
+  line2+="${SEP}${I_COST}${C_SUB}…(daily)${RST}"
+else
+  line2+="${SEP}${I_COST}${C_TEXT}$(fmt_jpy "$daily_raw")${RST}${C_SUB}(daily)${RST}"
+fi
 
-# 7日間のコスト
-weekly=$(fmt_jpy "$(weekly_cost)")
-[ -n "$weekly" ] && line2+="${SEP}${I_COST}${C_TEXT}${weekly}${RST}${C_SUB}(weekly)${RST}"
+# 7日間のコスト（キャッシュ未取得中は「…」で計算中を示す）
+weekly_raw=$(weekly_cost)
+if [ -z "$weekly_raw" ]; then
+  line2+="${SEP}${I_COST}${C_SUB}…(weekly)${RST}"
+else
+  line2+="${SEP}${I_COST}${C_TEXT}$(fmt_jpy "$weekly_raw")${RST}${C_SUB}(weekly)${RST}"
+fi
 
 printf '%s\n' "$line2"
 
@@ -325,10 +337,9 @@ printf '%s\n' "$line2"
 line3=""
 
 # コンテキスト使用率 (Ring Meter)
-if [ -n "$ctx_pct" ]; then
-  ctx_int=${ctx_pct%%.*}
-  line3+="ctx $(ring_meter "$ctx_int") ${C_TEXT}${ctx_int}%${RST}"
-fi
+ctx_int=${ctx_pct%%.*}
+ctx_int=${ctx_int:-0}
+line3+="ctx $(ring_meter "$ctx_int") ${C_TEXT}${ctx_int}%${RST}"
 
 # 5時間レート制限バー
 if [ -n "$fh_pct" ]; then

--- a/dot_claude/executable_statusline.sh
+++ b/dot_claude/executable_statusline.sh
@@ -2,12 +2,12 @@
 # Claude Code statusline - chezmoi 管理
 #
 # 表示レイアウト:
-#   行1: [フォルダ] ディレクトリ [| [GitHub] owner/repo] | [ブランチ] ブランチ名 ... | [フォーク] #PR番号 | [ツリー] worktree名
-#   行2: [ロボット] モデル | [ゲージ] effort | ● ステータス | [マネー] コスト
-#   行3: ctx [バー] % | [時計] 5h [バー] % HH:MM | [カレンダー] 7d [バー] % M/D HH:MM
+#   行1: [フォルダ] ディレクトリ [| [GitHub] owner/repo] | [ブランチ] ブランチ名 コンフリクト +staged ~unstaged ?untracked ⇡ahead⇣behind | PR #番号 | [ツリー] worktree名
+#   行2: [ロボット] モデル | [ゲージ] effort | [ステータス] OK/DEGRADED/DOWN | [円] 金額(session) | [円] 金額(daily) | [円] 金額(weekly)
+#   行3: ctx ○% | [時計] 5h [バー] % HH:MM | [カレンダー] 7d [バー] % M/D HH:MM
 #
-# 外部API・ccusage の取得部はコメントアウト済み。
-# 有効化するときは各「有効化時:」コメントを参照。
+# 為替レート(frankfurter.dev)の取得部はコメントアウト済み。
+# 有効化するときは usd_jpy_rate 関数のコメントを参照。
 
 # mise の PATH を補完（mise シェル外から起動された場合に bun/ccusage を解決するため）
 [ -n "$MISE_SHELL" ] || export PATH="$HOME/.local/share/mise/shims:$PATH"
@@ -52,21 +52,20 @@ C_ACCENT=$'\033[38;2;198;120;221m'  # #C678DD 紫  - 強調 (ブランチ名)
 SEP="${DIM} | ${RST}"
 
 # ── Nerd Font アイコン (Hack Nerd Font, raw UTF-8 バイト列) ───────────────────
-I_DIR=$'\xef\x81\xbb'        # nf-fa-folder       U+F07B
-I_BRANCH=$'\xee\x9c\xa5'     # nf-dev-git_branch  U+E725
-I_WT=$'\xf3\xb0\x99\x85'     # nf-md-file_tree    U+F0645
-I_MODEL=$'\xf3\xb0\x9a\xa9'  # nf-md-robot        U+F06A9
-I_EFFORT=$'\xef\x83\xa4'     # nf-fa-tachometer   U+F0E4
-I_5H=$'\xef\x80\x97'         # nf-fa-clock_o      U+F017
-I_7D=$'\xef\x81\xb3'         # nf-fa-calendar     U+F073
-I_COST=$'\xef\x85\x97'       # nf-fa-yen          U+F157
-I_PR=$'\xef\x84\xa6'         # nf-fa-code_fork    U+F126
-I_CONFLICT=$'\xef\x81\xb1'   # nf-fa-warning      U+F071
+I_DIR=$'\xef\x81\xbb'        # nf-fa-folder        U+F07B
+I_BRANCH=$'\xf3\xb0\x98\xac' # nf-md-source_branch U+F062C
+I_WT=$'\xf3\xb0\x99\x85'     # nf-md-file_tree     U+F0645
+I_MODEL=$'\xf3\xb0\x9a\xa9'  # nf-md-robot         U+F06A9
+I_EFFORT=$'\xef\x83\xa4'     # nf-fa-tachometer    U+F0E4
+I_5H=$'\xef\x80\x97'         # nf-fa-clock_o       U+F017
+I_7D=$'\xef\x81\xb3'         # nf-fa-calendar      U+F073
+I_COST=$'\xef\x85\x97'       # nf-fa-yen           U+F157
+I_CONFLICT=$'\xef\x81\xb1'   # nf-fa-warning       U+F071
 I_STATUS_OK=$'\xf3\xb0\x97\xa1'   # nf-md-check_circle_outline U+F05E1
 I_STATUS_WARN=$'\xf3\xb0\x97\x96' # nf-md-alert_circle_outline U+F05D6
 I_STATUS_DOWN=$'\xf3\xb0\x85\x9a' # nf-md-close_circle_outline U+F015A
-I_RETRY=$'\xef\x80\xa1'      # nf-fa-refresh      U+F021
-I_GITHUB=$'\xee\x9c\x89'     # nf-dev-github      U+E709
+I_RETRY=$'\xef\x80\xa1'      # nf-fa-refresh       U+F021
+I_GITHUB=$'\xee\x9c\x89'     # nf-dev-github       U+E709
 
 # ── キャッシュ設定 ─────────────────────────────────────────────────────────────
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline"
@@ -287,9 +286,9 @@ fi
 # PR 番号（URL がある場合は OSC 8 でクリッカブルリンクにする）
 if [ -n "$pr_num" ] && [ "$pr_num" != "0" ]; then
   if [ -n "$pr_url" ]; then
-    pr_seg="${I_PR} $(printf '\033]8;;%s\a#%s\033]8;;\a' "$pr_url" "$pr_num")"
+    pr_seg="$(printf '\033]8;;%s\aPR #%s\033]8;;\a' "$pr_url" "$pr_num")"
   else
-    pr_seg="${I_PR} #${pr_num}"
+    pr_seg="PR #${pr_num}"
   fi
   line1+="${SEP}${pr_seg}"
 fi
@@ -298,7 +297,7 @@ fi
 
 printf '%s\n' "$line1"
 
-# ── 行2: モデル | effort |  ステータス | コスト ─────────────────────────────
+# ── 行2: モデル | effort | ステータス | コスト ──────────────────────────────
 line2="${I_MODEL} ${model}"
 
 [ -n "$effort" ] && line2+="${SEP}${I_EFFORT} ${effort}"
@@ -322,10 +321,10 @@ weekly=$(fmt_jpy "$(weekly_cost)")
 
 printf '%s\n' "$line2"
 
-# ── 行3: コンテキストバー | 5時間レートバー | 7日間レートバー ─────────────────
+# ── 行3: ctx リングメーター | 5時間レートバー | 7日間レートバー ───────────────
 line3=""
 
-# コンテキスト使用率バー
+# コンテキスト使用率 (Ring Meter)
 if [ -n "$ctx_pct" ]; then
   ctx_int=${ctx_pct%%.*}
   line3+="ctx $(ring_meter "$ctx_int") ${ctx_int}%"

--- a/dot_claude/executable_statusline.sh
+++ b/dot_claude/executable_statusline.sh
@@ -43,11 +43,13 @@ IFS=$'\x1f' read -r model effort cwd project wt \
 # セマンティックな役割で定義し、用途ごとに使い分ける
 RST=$'\033[0m'
 DIM=$'\033[2m'
-C_OK=$'\033[38;2;78;201;148m'       # #4EC994 緑  - 正常 (staged)
-C_WARN=$'\033[38;2;226;181;106m'    # #E2B56A 黄  - 警告 (unstaged)
-C_DANGER=$'\033[38;2;224;108;117m'  # #E06C75 赤  - 危険 (コンフリクト)
-C_INFO=$'\033[38;2;97;175;239m'     # #61AFEF 青  - 情報 (ディレクトリ, ahead/behind)
-C_ACCENT=$'\033[38;2;198;120;221m'  # #C678DD 紫  - 強調 (ブランチ名)
+C_TEXT=$'\033[38;2;171;178;191m'    # #ABB2BF    - 基本テキスト (モデル, コスト金額, %)
+C_SUB=$'\033[38;2;130;137;151m'     # #828997    - 補助テキスト (ラベル, リセット時刻, 未追跡)
+C_OK=$'\033[38;2;78;201;148m'       # #4EC994 緑 - 正常 (staged)
+C_WARN=$'\033[38;2;226;181;106m'    # #E2B56A 黄 - 警告 (unstaged)
+C_DANGER=$'\033[38;2;224;108;117m'  # #E06C75 赤 - 危険 (コンフリクト)
+C_INFO=$'\033[38;2;97;175;239m'     # #61AFEF 青 - 情報 (ディレクトリ, ahead/behind)
+C_ACCENT=$'\033[38;2;198;120;221m'  # #C678DD 紫 - 強調 (ブランチ名)
 
 SEP="${DIM} | ${RST}"
 
@@ -275,7 +277,7 @@ if [ -n "$git_branch" ]; then
   [ "${git_conflicts:-0}" -gt 0 ] && git_seg+=" ${C_DANGER}${I_CONFLICT}${git_conflicts}${RST}"
   [ "${git_staged:-0}"    -gt 0 ] && git_seg+=" ${C_OK}+${git_staged}${RST}"
   [ "${git_unstaged:-0}"  -gt 0 ] && git_seg+=" ${C_WARN}~${git_unstaged}${RST}"
-  [ "${git_untracked:-0}" -gt 0 ] && git_seg+=" ${DIM}?${git_untracked}${RST}"
+  [ "${git_untracked:-0}" -gt 0 ] && git_seg+=" ${C_SUB}?${git_untracked}${RST}"
   [ "${git_ahead:-0}"     -gt 0 ] && git_seg+=" ${C_INFO}⇡${git_ahead}${RST}"
   [ "${git_behind:-0}"    -gt 0 ] && git_seg+=" ${C_INFO}⇣${git_behind}${RST}"
   line1+="${SEP}${git_seg}"
@@ -296,9 +298,9 @@ fi
 printf '%s\n' "$line1"
 
 # ── 行2: モデル | effort | ステータス | コスト ──────────────────────────────
-line2="${I_MODEL} ${model}"
+line2="${I_MODEL} ${C_TEXT}${model}${RST}"
 
-[ -n "$effort" ] && line2+="${SEP}${I_EFFORT} ${effort}"
+[ -n "$effort" ] && line2+="${SEP}${I_EFFORT} ${C_TEXT}${effort}${RST}"
 
 # Claude サービスステータス
 # 有効化時: status.claude.com API を実装し、状態に応じて
@@ -307,15 +309,15 @@ line2+="${SEP}${C_OK}$(printf '\033]8;;https://status.claude.com\a%s OK\033]8;;\
 
 # セッションコスト（JSON から取得、固定レートで円換算）
 session_cost=$(fmt_jpy "$cost_usd")
-[ -n "$session_cost" ] && line2+="${SEP}${I_COST}${session_cost}${DIM}(session)${RST}"
+[ -n "$session_cost" ] && line2+="${SEP}${I_COST}${C_TEXT}${session_cost}${RST}${C_SUB}(session)${RST}"
 
 # 1日のコスト
 daily=$(fmt_jpy "$(daily_cost)")
-[ -n "$daily" ] && line2+="${SEP}${I_COST}${daily}${DIM}(daily)${RST}"
+[ -n "$daily" ] && line2+="${SEP}${I_COST}${C_TEXT}${daily}${RST}${C_SUB}(daily)${RST}"
 
 # 7日間のコスト
 weekly=$(fmt_jpy "$(weekly_cost)")
-[ -n "$weekly" ] && line2+="${SEP}${I_COST}${weekly}${DIM}(weekly)${RST}"
+[ -n "$weekly" ] && line2+="${SEP}${I_COST}${C_TEXT}${weekly}${RST}${C_SUB}(weekly)${RST}"
 
 printf '%s\n' "$line2"
 
@@ -325,15 +327,15 @@ line3=""
 # コンテキスト使用率 (Ring Meter)
 if [ -n "$ctx_pct" ]; then
   ctx_int=${ctx_pct%%.*}
-  line3+="ctx $(ring_meter "$ctx_int") ${ctx_int}%"
+  line3+="ctx $(ring_meter "$ctx_int") ${C_TEXT}${ctx_int}%${RST}"
 fi
 
 # 5時間レート制限バー
 if [ -n "$fh_pct" ]; then
   fh_int=${fh_pct%%.*}
-  seg="${I_5H} 5h $(progress_bar "$fh_int" 10) ${fh_int}%"
+  seg="${I_5H} 5h $(progress_bar "$fh_int" 10) ${C_TEXT}${fh_int}%${RST}"
   if [ -n "$fh_reset" ] && [ "$fh_reset" != "0" ]; then
-    seg+=" ${DIM}${I_RETRY}$(fmt_epoch_jst "$fh_reset" '%H:%M')${RST}"
+    seg+=" ${C_SUB}${I_RETRY}$(fmt_epoch_jst "$fh_reset" '%H:%M')${RST}"
   fi
   line3+="${SEP}${seg}"
 fi
@@ -341,9 +343,9 @@ fi
 # 7日間レート制限バー
 if [ -n "$sd_pct" ]; then
   sd_int=${sd_pct%%.*}
-  seg="${I_7D} 7d $(progress_bar "$sd_int" 10) ${sd_int}%"
+  seg="${I_7D} 7d $(progress_bar "$sd_int" 10) ${C_TEXT}${sd_int}%${RST}"
   if [ -n "$sd_reset" ] && [ "$sd_reset" != "0" ]; then
-    seg+=" ${DIM}${I_RETRY}$(fmt_epoch_jst "$sd_reset" '%m/%d %H:%M')${RST}"
+    seg+=" ${C_SUB}${I_RETRY}$(fmt_epoch_jst "$sd_reset" '%m/%d %H:%M')${RST}"
   fi
   line3+="${SEP}${seg}"
 fi

--- a/dot_claude/executable_statusline.sh
+++ b/dot_claude/executable_statusline.sh
@@ -1,0 +1,354 @@
+#!/bin/bash
+# Claude Code statusline - chezmoi 管理
+#
+# 表示レイアウト:
+#   行1: [フォルダ] ディレクトリ [| [GitHub] owner/repo] | [ブランチ] ブランチ名 ... | [フォーク] #PR番号 | [ツリー] worktree名
+#   行2: [ロボット] モデル | [ゲージ] effort | ● ステータス | [マネー] コスト
+#   行3: ctx [バー] % | [時計] 5h [バー] % HH:MM | [カレンダー] 7d [バー] % M/D HH:MM
+#
+# 外部API・ccusage の取得部はコメントアウト済み。
+# 有効化するときは各「有効化時:」コメントを参照。
+
+# mise の PATH を補完（mise シェル外から起動された場合に bun/ccusage を解決するため）
+[ -n "$MISE_SHELL" ] || export PATH="$HOME/.local/share/mise/shims:$PATH"
+
+input=$(cat)
+
+# JSON フィールドを一括取得。フィールド区切りに \x1f (Unit Separator) を使用して
+# タブ・改行との衝突を回避する
+IFS=$'\x1f' read -r model effort cwd project wt \
+  ctx_pct cost_usd \
+  fh_pct fh_reset \
+  sd_pct sd_reset \
+  pr_num pr_url \
+  session_id \
+  < <(echo "$input" | jq -r '[
+  (.model.display_name // "Claude"),
+  (.effort.level // ""),
+  (.workspace.current_dir // .cwd // ""),
+  (.workspace.project_dir // ""),
+  (.workspace.git_worktree // ""),
+  (.context_window.used_percentage // ""),
+  (.cost.total_cost_usd // ""),
+  (.rate_limits.five_hour.used_percentage // ""),
+  (.rate_limits.five_hour.resets_at // ""),
+  (.rate_limits.seven_day.used_percentage // ""),
+  (.rate_limits.seven_day.resets_at // ""),
+  (if .pr.number then (.pr.number | tostring) else "" end),
+  (.pr.url // ""),
+  (.session_id // "")
+] | join("")')
+
+# ── カラーパレット (True Color / 24bit RGB) ────────────────────────────────────
+# セマンティックな役割で定義し、用途ごとに使い分ける
+RST=$'\033[0m'
+DIM=$'\033[2m'
+C_OK=$'\033[38;2;78;201;148m'       # #4EC994 緑  - 正常 (staged, ● OK)
+C_WARN=$'\033[38;2;226;181;106m'    # #E2B56A 黄  - 警告 (unstaged)
+C_DANGER=$'\033[38;2;224;108;117m'  # #E06C75 赤  - 危険 (コンフリクト)
+C_INFO=$'\033[38;2;97;175;239m'     # #61AFEF 青  - 情報 (ディレクトリ, ahead/behind)
+C_ACCENT=$'\033[38;2;198;120;221m'  # #C678DD 紫  - 強調 (ブランチ名)
+
+SEP="${DIM} | ${RST}"
+
+# ── Nerd Font アイコン (Hack Nerd Font, raw UTF-8 バイト列) ───────────────────
+I_DIR=$'\xef\x81\xbb'        # nf-fa-folder       U+F07B
+I_BRANCH=$'\xee\x9c\xa5'     # nf-dev-git_branch  U+E725
+I_WT=$'\xf3\xb0\x99\x85'     # nf-md-file_tree    U+F0645
+I_MODEL=$'\xf3\xb0\x9a\xa9'  # nf-md-robot        U+F06A9
+I_EFFORT=$'\xef\x83\xa4'     # nf-fa-tachometer   U+F0E4
+I_5H=$'\xef\x80\x97'         # nf-fa-clock_o      U+F017
+I_7D=$'\xef\x81\xb3'         # nf-fa-calendar     U+F073
+I_COST=$'\xef\x85\x97'       # nf-fa-yen          U+F157
+I_PR=$'\xef\x84\xa6'         # nf-fa-code_fork    U+F126
+I_CONFLICT=$'\xef\x81\xb1'   # nf-fa-warning      U+F071
+I_STATUS_OK=$'\xf3\xb0\x97\xa1'   # nf-md-check_circle_outline U+F05E1
+I_STATUS_WARN=$'\xf3\xb0\x97\x96' # nf-md-alert_circle_outline U+F05D6
+I_STATUS_DOWN=$'\xf3\xb0\x85\x9a' # nf-md-close_circle_outline U+F015A
+I_RETRY=$'\xef\x80\xa1'      # nf-fa-refresh      U+F021
+I_GITHUB=$'\xee\x9c\x89'     # nf-dev-github      U+E709
+
+# ── キャッシュ設定 ─────────────────────────────────────────────────────────────
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline"
+mkdir -p "$CACHE_DIR" 2>/dev/null && chmod 700 "$CACHE_DIR" 2>/dev/null
+
+# ファイルの最終更新時刻を Unix epoch 秒で返す
+file_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+# Unix epoch を日本時間 (JST) に変換して指定フォーマットで出力
+fmt_epoch_jst() {
+  TZ=Asia/Tokyo date -r "$1" "+$2" 2>/dev/null || \
+  TZ=Asia/Tokyo date -d "@$1" "+$2" 2>/dev/null
+}
+
+# ── Ring Meter ────────────────────────────────────────────────────────────────
+# 5段階の円形文字で使用率を1文字で表現する
+RINGS=('○' '◔' '◑' '◕' '●')
+
+# ring_meter <使用率%>
+# 使用率に応じた3段階カラー（緑/黄/赤）付きのリングメーターを出力する
+ring_meter() {
+  local pct=${1%%.*} idx color
+
+  [ -z "$pct" ] && pct=0
+
+  # 0-24%: ○  25-49%: ◔  50-74%: ◑  75-99%: ◕  100%: ●
+  idx=$(( pct >= 100 ? 4 : pct / 25 ))
+
+  # 3段階: ~60% 緑、~80% 黄、81%~ 赤
+  if   [ "$pct" -le 60 ]; then color="$C_OK"
+  elif [ "$pct" -le 80 ]; then color="$C_WARN"
+  else                          color="$C_DANGER"
+  fi
+
+  printf '%s%s%s' "$color" "${RINGS[$idx]}" "$RST"
+}
+
+# ── Fine Bar ──────────────────────────────────────────────────────────────────
+# Unicode ブロック文字 8段階で1文字あたり1/8刻みの精度を実現
+BLOCKS=(' ' '▏' '▎' '▍' '▌' '▋' '▊' '▉' '█')
+
+# progress_bar <使用率%> [バー幅=10]
+# 使用率に応じた3段階カラー（緑/黄/赤）付きのプログレスバーを出力する
+progress_bar() {
+  local pct=${1%%.*} width=${2:-10}
+  local filled_f full frac bar i empty color
+
+  [ -z "$pct" ] && pct=0
+
+  filled_f=$(awk -v p="$pct" -v w="$width" 'BEGIN{printf "%.6f", p*w/100}')
+  full=$(awk -v f="$filled_f" 'BEGIN{printf "%d", int(f)}')
+  frac=$(awk -v f="$filled_f" -v fi="$full" 'BEGIN{printf "%d", int((f-fi)*8)}')
+
+  # 3段階: ~60% 緑、~80% 黄、81%~ 赤
+  if   [ "$pct" -le 60 ]; then color="$C_OK"
+  elif [ "$pct" -le 80 ]; then color="$C_WARN"
+  else                          color="$C_DANGER"
+  fi
+
+  bar=""
+  for ((i = 0; i < full; i++)); do bar+='█'; done
+  if [ "$full" -lt "$width" ]; then
+    bar+="${BLOCKS[$frac]}"
+    empty=$((width - full - 1))
+    for ((i = 0; i < empty; i++)); do bar+='░'; done
+  fi
+
+  printf '%s%s%s' "$color" "$bar" "$RST"
+}
+
+# ── 為替レート (USD→JPY) ──────────────────────────────────────────────────────
+# 有効化時: 下記関数のコメントアウトを外し、JPY_RATE=160 の行を削除する
+# frankfurter.dev API を使用（日次キャッシュ、24時間 TTL）
+#
+# usd_jpy_rate() {
+#   local cache="$CACHE_DIR/usdjpy"
+#   local now mtime
+#   now=$(date +%s)
+#   mtime=$(file_mtime "$cache")
+#   if [ $((now - mtime)) -gt 86400 ]; then
+#     touch "$cache"
+#     (curl -s --max-time 3 \
+#       "https://api.frankfurter.dev/v1/latest?base=USD&symbols=JPY" 2>/dev/null |
+#       jq -r '.rates.JPY // empty' >"$cache.tmp" \
+#       && [ -s "$cache.tmp" ] && mv "$cache.tmp" "$cache") &
+#   fi
+#   cat "$cache" 2>/dev/null
+# }
+# JPY_RATE=$(usd_jpy_rate)
+JPY_RATE=160  # 固定値（有効化時は上記関数に置き換える）
+
+# USD を円換算してカンマ区切りで出力（例: ¥1,204）
+fmt_jpy() {
+  local usd="$1"
+  [ -z "$usd" ] && return
+  local jpy
+  jpy=$(awk -v u="$usd" -v r="$JPY_RATE" 'BEGIN{printf "%d", int(u*r+0.5)}')
+  [ "$jpy" = "0" ] && return
+  echo "$(echo "$jpy" | rev | sed 's/[0-9][0-9][0-9]/&,/g' | rev | sed 's/^,//')"
+}
+
+# ── 1日のコスト (ccusage, 5分キャッシュ) ─────────────────────────────────────
+daily_cost() {
+  local cache="$CACHE_DIR/daily_$(date +%Y%m%d)"
+  local now mtime
+  now=$(date +%s)
+  mtime=$(file_mtime "$cache")
+  if [ $((now - mtime)) -gt 300 ]; then
+    touch "$cache"
+    (ccusage daily --since "$(date +%Y%m%d)" --json 2>/dev/null |
+      jq -r '.totals.totalCost // empty' >"$cache.tmp" \
+      && mv "$cache.tmp" "$cache") &
+  fi
+  cat "$cache" 2>/dev/null
+}
+
+# ── 7日間のコスト (ccusage, 5分キャッシュ) ───────────────────────────────────
+weekly_cost() {
+  local cache="$CACHE_DIR/weekly_$(date +%Y%m%d)"
+  local now mtime
+  now=$(date +%s)
+  mtime=$(file_mtime "$cache")
+  if [ $((now - mtime)) -gt 300 ]; then
+    touch "$cache"
+    (ccusage weekly --json 2>/dev/null |
+      jq -r '.totals.totalCost // empty' >"$cache.tmp" \
+      && mv "$cache.tmp" "$cache") &
+  fi
+  cat "$cache" 2>/dev/null
+}
+
+# ── Git 情報 (session_id 別 5秒キャッシュ) ───────────────────────────────────
+GIT_CACHE="$CACHE_DIR/git-${session_id:-nosession}"
+now_ts=$(date +%s)
+git_mtime=$(file_mtime "$GIT_CACHE")
+
+if [ $((now_ts - git_mtime)) -gt 5 ]; then
+  git_dir="${cwd:-$(pwd)}"
+  if git -C "$git_dir" --no-optional-locks rev-parse --is-inside-work-tree \
+      >/dev/null 2>&1; then
+
+    branch=$(git -C "$git_dir" --no-optional-locks branch --show-current 2>/dev/null)
+    git_out=$(git -C "$git_dir" --no-optional-locks status --porcelain 2>/dev/null)
+
+    # ステータス別にファイル数を集計
+    # grep -c はマッチゼロでも stdout に "0" を出して exit 1 を返すため
+    # `|| echo 0` と組み合わせると "0\n0" になりキャッシュに \n が埋め込まれる
+    conflicts=$(echo "$git_out" | grep -cE '^(UU|AA|DD|AU|UA|DU|UD)' 2>/dev/null); conflicts=${conflicts:-0}
+    staged=$(echo "$git_out"    | grep -cE '^[MADRCT]'                2>/dev/null); staged=${staged:-0}
+    unstaged=$(echo "$git_out"  | grep -cE '^.[MDRCT]'                2>/dev/null); unstaged=${unstaged:-0}
+    untracked=$(echo "$git_out" | grep -c  '^??'                      2>/dev/null); untracked=${untracked:-0}
+
+    # upstream との ahead/behind コミット数
+    read -r behind ahead < <(
+      git -C "$git_dir" --no-optional-locks \
+        rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null
+    )
+
+    # GitHub の owner/repo を origin remote URL から抽出
+    # HTTPS: https://github.com/owner/repo.git  SSH: git@github.com:owner/repo.git
+    remote_url=$(git -C "$git_dir" --no-optional-locks remote get-url origin 2>/dev/null)
+    remote_slug=""
+    if [[ "$remote_url" =~ github\.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+      remote_slug="${BASH_REMATCH[1]}"
+    fi
+
+    printf '%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s' \
+      "${branch}" \
+      "${conflicts:-0}" "${staged:-0}" "${unstaged:-0}" "${untracked:-0}" \
+      "${behind:-0}" "${ahead:-0}" \
+      "${remote_slug}" \
+      > "$GIT_CACHE"
+  else
+    # Git リポジトリ外: 空エントリを書き込んでキャッシュを更新
+    printf '\x1f0\x1f0\x1f0\x1f0\x1f0\x1f0\x1f' > "$GIT_CACHE"
+  fi
+fi
+
+IFS=$'\x1f' read -r \
+  git_branch git_conflicts git_staged git_unstaged git_untracked \
+  git_behind git_ahead git_remote_slug \
+  < "$GIT_CACHE" 2>/dev/null
+
+# ── 行1: ディレクトリ | Git 情報 | worktree ──────────────────────────────────
+# プロジェクトルート配下にいる場合は「プロジェクト名/相対パス」形式で表示
+if [ -n "$project" ] && [ -n "$cwd" ] && [ "$cwd" != "$project" ]; then
+  case "$cwd" in
+    "$project"/*) dir_display="$(basename "$project")/${cwd#"$project"/}" ;;
+    *)            dir_display=$(basename "$cwd") ;;
+  esac
+else
+  dir_display=$(basename "${cwd:-$(pwd)}")
+fi
+
+line1="${I_DIR} ${C_INFO}${dir_display}${RST}"
+
+# ローカルパスが ghq 規則 (~/src/github.com/owner/repo) と異なる場合に GitHub slug を表示
+if [ -n "$git_remote_slug" ]; then
+  expected_path="$HOME/src/github.com/${git_remote_slug}"
+  if [ "${project:-$cwd}" != "$expected_path" ]; then
+    line1+="${SEP}${I_GITHUB} $(printf '\033]8;;https://github.com/%s\a%s\033]8;;\a' "$git_remote_slug" "$git_remote_slug")"
+  fi
+fi
+
+if [ -n "$git_branch" ]; then
+  git_seg="${C_ACCENT}${I_BRANCH} ${git_branch}${RST}"
+  [ "${git_conflicts:-0}" -gt 0 ] && git_seg+=" ${C_DANGER}${I_CONFLICT}${git_conflicts}${RST}"
+  [ "${git_staged:-0}"    -gt 0 ] && git_seg+=" ${C_OK}+${git_staged}${RST}"
+  [ "${git_unstaged:-0}"  -gt 0 ] && git_seg+=" ${C_WARN}~${git_unstaged}${RST}"
+  [ "${git_untracked:-0}" -gt 0 ] && git_seg+=" ${DIM}?${git_untracked}${RST}"
+  [ "${git_ahead:-0}"     -gt 0 ] && git_seg+=" ${C_INFO}⇡${git_ahead}${RST}"
+  [ "${git_behind:-0}"    -gt 0 ] && git_seg+=" ${C_INFO}⇣${git_behind}${RST}"
+  line1+="${SEP}${git_seg}"
+fi
+
+# PR 番号（URL がある場合は OSC 8 でクリッカブルリンクにする）
+if [ -n "$pr_num" ] && [ "$pr_num" != "0" ]; then
+  if [ -n "$pr_url" ]; then
+    pr_seg="${I_PR} $(printf '\033]8;;%s\a#%s\033]8;;\a' "$pr_url" "$pr_num")"
+  else
+    pr_seg="${I_PR} #${pr_num}"
+  fi
+  line1+="${SEP}${pr_seg}"
+fi
+
+[ -n "$wt" ] && line1+="${SEP}${I_WT} ${wt}"
+
+printf '%s\n' "$line1"
+
+# ── 行2: モデル | effort |  ステータス | コスト ─────────────────────────────
+line2="${I_MODEL} ${model}"
+
+[ -n "$effort" ] && line2+="${SEP}${I_EFFORT} ${effort}"
+
+# Claude サービスステータス
+# 有効化時: status.claude.com API を実装し、状態に応じて
+#   OK → ${C_OK}${I_STATUS_OK}  DEGRADED → ${C_WARN}${I_STATUS_WARN}  DOWN → ${C_DANGER}${I_STATUS_DOWN}
+line2+="${SEP}${C_OK}$(printf '\033]8;;https://status.claude.com\a%s OK\033]8;;\a' "${I_STATUS_OK}")${RST}"
+
+# セッションコスト（JSON から取得、固定レートで円換算）
+session_cost=$(fmt_jpy "$cost_usd")
+[ -n "$session_cost" ] && line2+="${SEP}${I_COST}${session_cost}${DIM}(session)${RST}"
+
+# 1日のコスト
+daily=$(fmt_jpy "$(daily_cost)")
+[ -n "$daily" ] && line2+="${SEP}${I_COST}${daily}${DIM}(daily)${RST}"
+
+# 7日間のコスト
+weekly=$(fmt_jpy "$(weekly_cost)")
+[ -n "$weekly" ] && line2+="${SEP}${I_COST}${weekly}${DIM}(weekly)${RST}"
+
+printf '%s\n' "$line2"
+
+# ── 行3: コンテキストバー | 5時間レートバー | 7日間レートバー ─────────────────
+line3=""
+
+# コンテキスト使用率バー
+if [ -n "$ctx_pct" ]; then
+  ctx_int=${ctx_pct%%.*}
+  line3+="ctx $(ring_meter "$ctx_int") ${ctx_int}%"
+fi
+
+# 5時間レート制限バー
+if [ -n "$fh_pct" ]; then
+  fh_int=${fh_pct%%.*}
+  seg="${I_5H} 5h $(progress_bar "$fh_int" 10) ${fh_int}%"
+  if [ -n "$fh_reset" ] && [ "$fh_reset" != "0" ]; then
+    seg+=" ${DIM}${I_RETRY}$(fmt_epoch_jst "$fh_reset" '%H:%M')${RST}"
+  fi
+  line3+="${SEP}${seg}"
+fi
+
+# 7日間レート制限バー
+if [ -n "$sd_pct" ]; then
+  sd_int=${sd_pct%%.*}
+  seg="${I_7D} 7d $(progress_bar "$sd_int" 10) ${sd_int}%"
+  if [ -n "$sd_reset" ] && [ "$sd_reset" != "0" ]; then
+    seg+=" ${DIM}${I_RETRY}$(fmt_epoch_jst "$sd_reset" '%m/%d %H:%M')${RST}"
+  fi
+  line3+="${SEP}${seg}"
+fi
+
+[ -n "$line3" ] && printf '%s\n' "$line3"

--- a/dot_claude/executable_statusline.sh
+++ b/dot_claude/executable_statusline.sh
@@ -43,7 +43,7 @@ IFS=$'\x1f' read -r model effort cwd project wt \
 # セマンティックな役割で定義し、用途ごとに使い分ける
 RST=$'\033[0m'
 DIM=$'\033[2m'
-C_OK=$'\033[38;2;78;201;148m'       # #4EC994 緑  - 正常 (staged, ● OK)
+C_OK=$'\033[38;2;78;201;148m'       # #4EC994 緑  - 正常 (staged)
 C_WARN=$'\033[38;2;226;181;106m'    # #E2B56A 黄  - 警告 (unstaged)
 C_DANGER=$'\033[38;2;224;108;117m'  # #E06C75 赤  - 危険 (コンフリクト)
 C_INFO=$'\033[38;2;97;175;239m'     # #61AFEF 青  - 情報 (ディレクトリ, ahead/behind)
@@ -52,20 +52,20 @@ C_ACCENT=$'\033[38;2;198;120;221m'  # #C678DD 紫  - 強調 (ブランチ名)
 SEP="${DIM} | ${RST}"
 
 # ── Nerd Font アイコン (Hack Nerd Font, raw UTF-8 バイト列) ───────────────────
-I_DIR=$'\xef\x81\xbb'        # nf-fa-folder        U+F07B
-I_BRANCH=$'\xf3\xb0\x98\xac' # nf-md-source_branch U+F062C
-I_WT=$'\xf3\xb0\x99\x85'     # nf-md-file_tree     U+F0645
-I_MODEL=$'\xf3\xb0\x9a\xa9'  # nf-md-robot         U+F06A9
-I_EFFORT=$'\xef\x83\xa4'     # nf-fa-tachometer    U+F0E4
-I_5H=$'\xef\x80\x97'         # nf-fa-clock_o       U+F017
-I_7D=$'\xef\x81\xb3'         # nf-fa-calendar      U+F073
-I_COST=$'\xef\x85\x97'       # nf-fa-yen           U+F157
-I_CONFLICT=$'\xef\x81\xb1'   # nf-fa-warning       U+F071
+I_DIR=$'\xef\x81\xbb'             # nf-fa-folder               U+F07B
+I_BRANCH=$'\xf3\xb0\x98\xac'      # nf-md-source_branch        U+F062C
+I_WT=$'\xf3\xb0\x99\x85'          # nf-md-file_tree            U+F0645
+I_MODEL=$'\xf3\xb0\x9a\xa9'       # nf-md-robot                U+F06A9
+I_EFFORT=$'\xef\x83\xa4'          # nf-fa-tachometer           U+F0E4
+I_5H=$'\xef\x80\x97'              # nf-fa-clock_o              U+F017
+I_7D=$'\xef\x81\xb3'              # nf-fa-calendar             U+F073
+I_COST=$'\xef\x85\x97'            # nf-fa-yen                  U+F157
+I_CONFLICT=$'\xef\x81\xb1'        # nf-fa-warning              U+F071
 I_STATUS_OK=$'\xf3\xb0\x97\xa1'   # nf-md-check_circle_outline U+F05E1
 I_STATUS_WARN=$'\xf3\xb0\x97\x96' # nf-md-alert_circle_outline U+F05D6
 I_STATUS_DOWN=$'\xf3\xb0\x85\x9a' # nf-md-close_circle_outline U+F015A
-I_RETRY=$'\xef\x80\xa1'      # nf-fa-refresh       U+F021
-I_GITHUB=$'\xee\x9c\x89'     # nf-dev-github       U+E709
+I_RETRY=$'\xef\x80\xa1'           # nf-fa-refresh              U+F021
+I_GITHUB=$'\xee\x9c\x89'          # nf-dev-github              U+E709
 
 # ── キャッシュ設定 ─────────────────────────────────────────────────────────────
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-statusline"
@@ -99,7 +99,7 @@ ring_meter() {
   # 3段階: ~60% 緑、~80% 黄、81%~ 赤
   if   [ "$pct" -le 60 ]; then color="$C_OK"
   elif [ "$pct" -le 80 ]; then color="$C_WARN"
-  else                          color="$C_DANGER"
+  else                         color="$C_DANGER"
   fi
 
   printf '%s%s%s' "$color" "${RINGS[$idx]}" "$RST"
@@ -124,7 +124,7 @@ progress_bar() {
   # 3段階: ~60% 緑、~80% 黄、81%~ 赤
   if   [ "$pct" -le 60 ]; then color="$C_OK"
   elif [ "$pct" -le 80 ]; then color="$C_WARN"
-  else                          color="$C_DANGER"
+  else                         color="$C_DANGER"
   fi
 
   bar=""
@@ -139,25 +139,23 @@ progress_bar() {
 }
 
 # ── 為替レート (USD→JPY) ──────────────────────────────────────────────────────
-# 有効化時: 下記関数のコメントアウトを外し、JPY_RATE=160 の行を削除する
 # frankfurter.dev API を使用（日次キャッシュ、24時間 TTL）
-#
-# usd_jpy_rate() {
-#   local cache="$CACHE_DIR/usdjpy"
-#   local now mtime
-#   now=$(date +%s)
-#   mtime=$(file_mtime "$cache")
-#   if [ $((now - mtime)) -gt 86400 ]; then
-#     touch "$cache"
-#     (curl -s --max-time 3 \
-#       "https://api.frankfurter.dev/v1/latest?base=USD&symbols=JPY" 2>/dev/null |
-#       jq -r '.rates.JPY // empty' >"$cache.tmp" \
-#       && [ -s "$cache.tmp" ] && mv "$cache.tmp" "$cache") &
-#   fi
-#   cat "$cache" 2>/dev/null
-# }
-# JPY_RATE=$(usd_jpy_rate)
-JPY_RATE=160  # 固定値（有効化時は上記関数に置き換える）
+
+usd_jpy_rate() {
+  local cache="$CACHE_DIR/usdjpy"
+  local now mtime
+  now=$(date +%s)
+  mtime=$(file_mtime "$cache")
+  if [ $((now - mtime)) -gt 86400 ]; then
+    touch "$cache"
+    (curl -s --max-time 3 \
+      "https://api.frankfurter.dev/v1/latest?base=USD&symbols=JPY" 2>/dev/null |
+      jq -r '.rates.JPY // empty' >"$cache.tmp" \
+      && [ -s "$cache.tmp" ] && mv "$cache.tmp" "$cache") &
+  fi
+  cat "$cache" 2>/dev/null
+}
+JPY_RATE=$(usd_jpy_rate)
 
 # USD を円換算してカンマ区切りで出力（例: ¥1,204）
 fmt_jpy() {
@@ -216,9 +214,9 @@ if [ $((now_ts - git_mtime)) -gt 5 ]; then
     # grep -c はマッチゼロでも stdout に "0" を出して exit 1 を返すため
     # `|| echo 0` と組み合わせると "0\n0" になりキャッシュに \n が埋め込まれる
     conflicts=$(echo "$git_out" | grep -cE '^(UU|AA|DD|AU|UA|DU|UD)' 2>/dev/null); conflicts=${conflicts:-0}
-    staged=$(echo "$git_out"    | grep -cE '^[MADRCT]'                2>/dev/null); staged=${staged:-0}
-    unstaged=$(echo "$git_out"  | grep -cE '^.[MDRCT]'                2>/dev/null); unstaged=${unstaged:-0}
-    untracked=$(echo "$git_out" | grep -c  '^??'                      2>/dev/null); untracked=${untracked:-0}
+    staged=$(echo "$git_out"    | grep -cE '^[MADRCT]'               2>/dev/null); staged=${staged:-0}
+    unstaged=$(echo "$git_out"  | grep -cE '^.[MDRCT]'               2>/dev/null); unstaged=${unstaged:-0}
+    untracked=$(echo "$git_out" | grep -c  '^??'                     2>/dev/null); untracked=${untracked:-0}
 
     # upstream との ahead/behind コミット数
     read -r behind ahead < <(

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -18,7 +18,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": ""
+    "command": "~/.claude/statusline.sh"
   },
   "enabledPlugins": {
     "github@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

- `~/.claude/statusline.sh` を chezmoi 管理のスクリプトとして追加
- Claude Code の `statusLine.command` に設定し、3行のカスタムステータスラインを実装
- `dot_Brewfile` に `ccusage`・`mas` を追加

## 表示内容

**行1:** ディレクトリ | [GitHubリポジトリ] | ブランチ名 (+staged ~unstaged ?untracked ⇡⇣) | #PR | worktree  
**行2:** モデル | effort | ステータス(status.claude.comリンク) | コスト(session/daily/weekly)  
**行3:** ctx リングメーター% | 5h バー% リセット時刻 | 7d バー% リセット日時  

## 主な技術仕様

- **アイコン:** Hack Nerd Font (raw UTF-8バイト列で定義)
- **カラー:** True Color / One Dark インスパイアのセマンティックパレット
- **コンテキスト:** Ring Meter (`○◔◑◕●`) で1文字表示
- **トークン使用量:** Fine Bar (Unicode ブロック文字8段階) で表示
- **コスト:** ccusage によるデイリー・週次コスト、5分キャッシュ
- **リンク:** OSC 8 ハイパーリンクで GitHub リポジトリ・PR・Claude ステータスページをクリッカブルに
- **キャッシュ:** Git情報 5秒TTL、コスト 5分TTL、為替レート 24時間TTL

## Test plan

- [ ] chezmoi apply 後に `~/.claude/statusline.sh` が実行権限付きで配置されること
- [ ] Claude Code 起動時にステータスラインが3行表示されること
- [ ] Git リポジトリ内でブランチ名・変更数が表示されること
- [ ] ghq 管理外リポジトリで GitHub slug が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)